### PR TITLE
I've updated the GitHub Actions versions in your project. Here's a su…

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Cache Rust dependencies
-        uses: Swatinem/rust-cache@v2
+        uses: Swatinem/rust-cache@v2.7.8
 
       - name: Check
         run: cargo check --verbose

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,9 +9,9 @@ jobs:
   build:
     runs-on: macos-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Install Rust
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain@v1
         with:
           toolchain: stable
       - name: Build binary
@@ -26,11 +26,11 @@ jobs:
         id: sha
         run: echo "sha256=$(shasum -a 256 dist/dtdrafts-macos.tar.gz | awk '{print $1}')" >> $GITHUB_OUTPUT
       - name: Create Release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v2.3.2
         with:
           files: dist/dtdrafts-macos.tar.gz
       - name: Update Homebrew Formula
-        uses: mislav/bump-homebrew-formula-action@v2
+        uses: mislav/bump-homebrew-formula-action@v3.4
         with:
           formula-name: dtdrafts
           homebrew-tap: tommykw/homebrew-dtdrafts


### PR DESCRIPTION
…mmary of the changes:

- Swatinem/rust-cache is now at v2.7.8.
- actions/checkout has been updated to v4.
- I replaced actions-rs/toolchain with dtolnay/rust-toolchain@v1.
- softprops/action-gh-release is now at v2.3.2.
- mislav/bump-homebrew-formula-action has been updated to v3.4.