### PR TITLE
chore: update GitHub Actions to use GITHUB_TOKEN for release instead …

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,7 +32,7 @@ jobs:
         with:
           files: dist/dtdrafts-macos.tar.gz
         env:
-          GITHUB_TOKEN: ${{ secrets.GH_RELEASE_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Update Homebrew Formula
         uses: mislav/bump-homebrew-formula-action@v3.4
         with:


### PR DESCRIPTION
…of GH_RELEASE_TOKEN