### PR TITLE
fix: remove @ symbol from URLs in search results

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -175,7 +175,7 @@ pub fn display_articles(articles: &[&Article]) {
     println!("{} draft article(s) found:\n", articles.len().to_string().green().bold());
     for (i, article) in articles.iter().enumerate() {
         println!("{}. {}", i + 1, article.title.cyan().bold());
-        let edit_url = format!("@https://dev.to/{}/{}/edit", article.user.username, article.slug);
+        let edit_url = format!("https://dev.to/{}/{}/edit", article.user.username, article.slug);
         println!("{}", edit_url.blue().underline());
         println!();
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -46,8 +46,7 @@ async fn main() -> Result<()> {
         let est_pages = (prev_cache_count as f64 / 1000.0).ceil() as u64;
         let est_time = est_pages;
         println!(
-            "Current cache: {} articles. Estimated time to refresh: about {} seconds ({} pages).",
-            prev_cache_count, est_time, est_pages
+            "Current cache: {prev_cache_count} articles. Estimated time to refresh: about {est_time} seconds ({est_pages} pages)."
         );
     }
     let articles = if cli.refresh || load_articles_cache().unwrap_or_default().is_empty() {


### PR DESCRIPTION
Remove the @ prefix from URLs displayed in search results to make them properly clickable and usable.

🤖 Generated with [Claude Code](https://claude.ai/code)